### PR TITLE
Improvements to Streamlit dashboard

### DIFF
--- a/Streamlit Dashboard/app.yaml
+++ b/Streamlit Dashboard/app.yaml
@@ -29,7 +29,7 @@ variables:
   - name: threshold_good
     inputType: FreeText
     description: Sentiment values greater than this value are considered 'Good'.
-    defaultValue: 0
+    defaultValue: 0.25
     required: true
   - name: threshold_bad
     inputType: FreeText

--- a/Streamlit Dashboard/app.yaml
+++ b/Streamlit Dashboard/app.yaml
@@ -28,7 +28,7 @@ variables:
     required: false
   - name: threshold_good
     inputType: FreeText
-    description: Sentiment threshold equal to or greater than of which are considered 'Good'.
+    description: Sentiment values greater than this value are considered 'Good'.
     defaultValue: 0
     required: true
   - name: threshold_bad

--- a/Streamlit Dashboard/app.yaml
+++ b/Streamlit Dashboard/app.yaml
@@ -31,6 +31,11 @@ variables:
     description: Sentiment threshold equal to or greater than of which are considered 'Good'.
     defaultValue: 0
     required: true
+  - name: threshold_bad
+    inputType: FreeText
+    description: Sentiment values below which are considered 'Bad'.
+    defaultValue: 0
+    required: true
 dockerfile: build/dockerfile
 runEntryPoint: main.py
 defaultFile: main.py

--- a/Streamlit Dashboard/app.yaml
+++ b/Streamlit Dashboard/app.yaml
@@ -26,11 +26,6 @@ variables:
     description: Custom style sheet for Streamlit.
     defaultValue: style.css
     required: false
-  - name: threshold_good
-    inputType: FreeText
-    description: Sentiment values greater than this value are considered 'Good'.
-    defaultValue: 0.25
-    required: true
   - name: threshold_bad
     inputType: FreeText
     description: Sentiment values below which are considered 'Bad'.

--- a/Streamlit Dashboard/app.yaml
+++ b/Streamlit Dashboard/app.yaml
@@ -26,11 +26,6 @@ variables:
     description: Custom style sheet for Streamlit.
     defaultValue: style.css
     required: false
-  - name: threshold_bad
-    inputType: FreeText
-    description: Sentiment values below which are considered 'Bad'.
-    defaultValue: -0.25
-    required: true
 dockerfile: build/dockerfile
 runEntryPoint: main.py
 defaultFile: main.py

--- a/Streamlit Dashboard/app.yaml
+++ b/Streamlit Dashboard/app.yaml
@@ -26,6 +26,11 @@ variables:
     description: Custom style sheet for Streamlit.
     defaultValue: style.css
     required: false
+  - name: threshold_good
+    inputType: FreeText
+    description: Sentiment threshold equal to or greater than of which are considered 'Good'.
+    defaultValue: 0
+    required: true
 dockerfile: build/dockerfile
 runEntryPoint: main.py
 defaultFile: main.py

--- a/Streamlit Dashboard/app.yaml
+++ b/Streamlit Dashboard/app.yaml
@@ -34,7 +34,7 @@ variables:
   - name: threshold_bad
     inputType: FreeText
     description: Sentiment values below which are considered 'Bad'.
-    defaultValue: 0
+    defaultValue: -0.25
     required: true
 dockerfile: build/dockerfile
 runEntryPoint: main.py

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -80,11 +80,11 @@ while True:
             msg_latest = chats[i][-1]
             mood_avg = ""
             if msg_latest["average_sentiment"] > float(os.environ["threshold_good"]):
-                mood_avg = "**:green[Good]**"
+                mood_avg = f"**:green[Good ({msg_latest['average_sentiment']:.2f})]**"
             elif msg_latest["average_sentiment"] < float(os.environ["threshold_bad"]):
-                mood_avg = "**:red[Bad]**"
+                mood_avg = f"**:red[Bad ({msg_latest['average_sentiment']:.2f})]**"
             else:
-                mood_avg = "**:orange[Neutral]**"
+                mood_avg = f"**:orange[Neutral ({msg_latest['average_sentiment']:.2f})]**"
 
             with c[0].container():
                 st.subheader(f"Conversation #{i + 1}")

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -97,9 +97,9 @@ while True:
     if "timestamp" in sentiment_data and len(sentiment_data["timestamp"]) > 0:
         with chart_title.container():
             st.subheader("Customer Success Team")
-            st.text("SENTIMENT DASHBOARD")
+            st.markdown("SENTIMENT DASHBOARD")
             st.markdown("#")
-            st.text("Sentiment History")
+            st.markdown("Sentiment History")
 
         with chart.container(border=True):
             chart_data = pd.DataFrame.from_dict(sentiment_data, orient="index").T

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -52,6 +52,13 @@ def get_emoji(sentiment: float):
         return "😡"
     return "😐"
 
+def confidence_to_sentiment(confidence: float):
+    if confidence < 0:
+        return -1
+    if confidence > 0:
+        return 1
+    return 0
+
 while True:
     count = 0
     chats = []
@@ -98,7 +105,7 @@ while True:
             chat_name = get_chat_name(i)
             for msg in chats[i]:
                 sentiment_data["timestamp"].append(msg["timestamp"])                
-                sentiment_data["sentiment"].append(msg["sentiment"])                
+                sentiment_data["sentiment"].append(confidence_to_sentiment(msg["sentiment"]))
                 sentiment_data["conversation"].append(get_chat_name(i))                
 
     if "timestamp" in sentiment_data and len(sentiment_data["timestamp"]) > 0:

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -78,11 +78,11 @@ while True:
             msg_latest = chats[i][-1]
             mood_avg = ""
             if msg_latest["average_sentiment"] > 0:
-                mood_avg = f"**:green[Good ({abs(msg_latest['average_sentiment']) * 100:.0f}%)]**"
+                mood_avg = f"**:green[Good]**"
             elif msg_latest["average_sentiment"] < 0:
-                mood_avg = f"**:red[Bad ({abs(msg_latest['average_sentiment']) * 100:.0f}%)]**"
+                mood_avg = f"**:red[Bad]**"
             else:
-                mood_avg = f"**:orange[Neutral ({abs(msg_latest['average_sentiment']) * 100:.0f}%)]**"
+                mood_avg = f"**:orange[Neutral]**"
 
             with c[0].container():
                 st.subheader(f"Conversation #{i + 1}")

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -70,23 +70,23 @@ while True:
         if i < len(chats):
             msg_latest = chats[i][-1]
             mood_avg = ""
-            if msg_latest["average_sentiment"] > os.environ["threshold_good"]:
+            if msg_latest["average_sentiment"] > float(os.environ["threshold_good"]):
                 mood_avg = "**:green[Good]**"
-            elif msg_latest["average_sentiment"] < os.environ["threshold_bad"]:
+            elif msg_latest["average_sentiment"] < float(os.environ["threshold_bad"]):
                 mood_avg = "**:red[Bad]**"
             else:
                 mood_avg = "**:yellow[Neutral]**"
 
             with c[0].container():
                 st.subheader(f"Conversation #{i + 1}")
-                st.text(f"Agent ID: {msg_latest['agent_id']:.0f} ({msg_latest['agent_name']})")
-                st.text(f"Customer ID: {msg_latest['customer_id']:.0f} ({msg_latest['customer_name']})")
-                st.markdown("Average Sentiment: " + mood_avg)
+                st.markdown(f"**Agent ID:** {msg_latest['agent_id']:.0f} ({msg_latest['agent_name']})")
+                st.markdown(f"**Customer ID:** {msg_latest['customer_id']:.0f} ({msg_latest['customer_name']})")
+                st.markdown(f"**Average Sentiment:** {mood_avg}")
             
             with c[1].container(border=True):
                 for msg in chats[i]:
                     with st.chat_message("human" if msg["role"] == "customer" else "assistant"):
-                        st.markdown(msg["text"])
+                        st.markdown(msg["text"] + "")
 
             chat_name = get_chat_name(i)
             for msg in chats[i]:

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -84,12 +84,12 @@ while True:
         if i < len(chats):
             msg_latest = chats[i][-1]
             mood_avg = ""
-            if msg_latest["average_sentiment"] > 0:
-                mood_avg = "**:green[Good]**"
-            elif msg_latest["average_sentiment"] < 0:
-                mood_avg = "**:red[Bad]**"
+            if msg_latest["average_sentiment"] > float(os.environ["threshold_good"]):
+                mood_avg = f"**:green[Good ({msg_latest['average_sentiment']:.2f})]**"
+            elif msg_latest["average_sentiment"] < float(os.environ["threshold_bad"]):
+                mood_avg = f"**:red[Bad ({msg_latest['average_sentiment']:.2f})]**"
             else:
-                mood_avg = "**:orange[Neutral]**"
+                mood_avg = f"**:orange[Neutral ({msg_latest['average_sentiment']:.2f})]**"
 
             with c[0].container():
                 st.subheader(f"Conversation #{i + 1}")

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -45,6 +45,13 @@ alt_y = alt.Y("sentiment", axis=None)
 alt_legend = alt.Legend(title=None, orient="bottom", direction="vertical")
 alt_color = alt.Color("conversation", legend=alt_legend)
 
+def get_text_color(sentiment: float):
+    if sentiment < float(os.environ["threshold_bad"]):
+        return "red"
+    if sentiment > float(os.environ["threshold_good"]):
+        return "green"
+    return "yellow"
+
 while True:
     count = 0
     chats = []
@@ -86,7 +93,7 @@ while True:
             with c[1].container(border=True):
                 for msg in chats[i]:
                     with st.chat_message("human" if msg["role"] == "customer" else "assistant"):
-                        st.markdown(msg["text"] + "")
+                        st.markdown(f"{msg['text']} :{get_text_color(msg['sentiment'])}[[{msg['sentiment']:.2f}]]")
 
             chat_name = get_chat_name(i)
             for msg in chats[i]:

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -119,7 +119,7 @@ while True:
             chart_data = pd.DataFrame.from_dict(sentiment_data, orient="index").T
             chart_data.sort_values("timestamp", inplace=True)
             alt_chart = alt.Chart(chart_data) \
-                    .mark_line() \
+                    .mark_line(interpolate='step-after') \
                     .encode(x=alt_x, y=alt_y, color=alt_color) \
 
             st.altair_chart(alt_chart, use_container_width=True)

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -84,9 +84,9 @@ while True:
         if i < len(chats):
             msg_latest = chats[i][-1]
             mood_avg = ""
-            if msg_latest["average_sentiment"] > float(os.environ["threshold_good"]):
+            if msg_latest["average_sentiment"] > 0:
                 mood_avg = f"**:green[Good ({msg_latest['average_sentiment']:.2f})]**"
-            elif msg_latest["average_sentiment"] < float(os.environ["threshold_bad"]):
+            elif msg_latest["average_sentiment"] < 0:
                 mood_avg = f"**:red[Bad ({msg_latest['average_sentiment']:.2f})]**"
             else:
                 mood_avg = f"**:orange[Neutral ({msg_latest['average_sentiment']:.2f})]**"

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -82,7 +82,7 @@ while True:
             elif msg_latest["average_sentiment"] < float(os.environ["threshold_bad"]):
                 mood_avg = "**:red[Bad]**"
             else:
-                mood_avg = "**:yellow[Neutral]**"
+                mood_avg = "**:orange[Neutral]**"
 
             with c[0].container():
                 st.subheader(f"Conversation #{i + 1}")

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -70,8 +70,6 @@ while True:
             if count >= maxlen:
                 break
     
-    print(f"Discovered keys={count}, prefix={key_prefix}")
-    
     for i, c in enumerate(containers):
         c[0].empty()
         c[1].empty()

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -71,17 +71,17 @@ while True:
             msg_latest = chats[i][-1]
             mood_avg = ""
             if msg_latest["average_sentiment"] > 0:
-                mood_avg = "Good"
+                mood_avg = "**:green[Good]**"
             elif msg_latest["average_sentiment"] < 0:
-                mood_avg = "Bad"
+                mood_avg = "**:red[Bad]**"
             else:
-                mood_avg = "Neutral"
+                mood_avg = "**:yellow[Neutral]**"
 
             with c[0].container():
                 st.subheader(f"Conversation #{i + 1}")
                 st.text(f"Agent ID: {msg_latest['agent_id']:.0f} ({msg_latest['agent_name']})")
                 st.text(f"Customer ID: {msg_latest['customer_id']:.0f} ({msg_latest['customer_name']})")
-                st.text("Average Sentiment: " + mood_avg)
+                st.markdown("Average Sentiment: " + mood_avg)
             
             with c[1].container(border=True):
                 for msg in chats[i]:

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -50,7 +50,7 @@ while True:
     chats = []
     sentiment_data = {}
 
-    for key in r.scan_iter(key_prefix) :
+    for key in r.scan_iter(key_prefix + "*") :
         chat = r.json().get(key)
         # customer_id is not available until the customer responds to agent
         if chat and "customer_name" in chat[-1] and chat[-1]["customer_name"]:
@@ -85,7 +85,7 @@ while True:
             
             with c[1].container(border=True):
                 for msg in chats[i]:
-                    with st.chat_message(msg["role"]):
+                    with st.chat_message("human" if msg["role"] == "customer" else "assistant"):
                         st.markdown(msg["text"])
 
             chat_name = get_chat_name(i)

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -70,6 +70,8 @@ while True:
             if count >= maxlen:
                 break
     
+    print(f"Discovered keys={count}, prefix={key_prefix}")
+    
     for i, c in enumerate(containers):
         c[0].empty()
         c[1].empty()

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -93,7 +93,8 @@ while True:
             with c[1].container(border=True):
                 for msg in chats[i]:
                     with st.chat_message("human" if msg["role"] == "customer" else "assistant"):
-                        st.markdown(f"{msg['text']} :{get_text_color(msg['sentiment'])}[[{msg['sentiment']:.2f}]]")
+                        st.markdown(f"{msg['text']} <div style='text-align: right; color: {get_text_color(msg['sentiment'])}'>[{msg['sentiment']:.2f}]</div>", unsafe_allow_html=True)
+                        #st.markdown(f"{msg['text']} :{get_text_color(msg['sentiment'])}[[{msg['sentiment']:.2f}]]")
 
             chat_name = get_chat_name(i)
             for msg in chats[i]:

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -50,19 +50,18 @@ while True:
     chats = []
     sentiment_data = {}
 
-    for key in r.scan_iter() :
-        if key.decode().startswith(key_prefix):
-            chat = r.json().get(key)
-            # customer_id is not available until the customer responds to agent
-            if chat and "customer_name" in chat[-1] and chat[-1]["customer_name"]:
-                chats.append(chat)
-                sentiment_data["timestamp"] = []
-                sentiment_data["sentiment"] = []
-                sentiment_data["conversation"] = []
-                count += 1
-                # limit the number of chats displayed
-                if count >= maxlen:
-                    break
+    for key in r.scan_iter(key_prefix) :
+        chat = r.json().get(key)
+        # customer_id is not available until the customer responds to agent
+        if chat and "customer_name" in chat[-1] and chat[-1]["customer_name"]:
+            chats.append(chat)
+            sentiment_data["timestamp"] = []
+            sentiment_data["sentiment"] = []
+            sentiment_data["conversation"] = []
+            count += 1
+            # limit the number of chats displayed
+            if count >= maxlen:
+                break
     
     for i, c in enumerate(containers):
         c[0].empty()

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -70,9 +70,9 @@ while True:
         if i < len(chats):
             msg_latest = chats[i][-1]
             mood_avg = ""
-            if msg_latest["average_sentiment"] > 0:
+            if msg_latest["average_sentiment"] > os.environ["threshold_good"]:
                 mood_avg = "**:green[Good]**"
-            elif msg_latest["average_sentiment"] < 0:
+            elif msg_latest["average_sentiment"] < os.environ["threshold_bad"]:
                 mood_avg = "**:red[Bad]**"
             else:
                 mood_avg = "**:yellow[Neutral]**"

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -46,9 +46,9 @@ alt_legend = alt.Legend(title=None, orient="bottom", direction="vertical")
 alt_color = alt.Color("conversation", legend=alt_legend)
 
 def get_text_color(sentiment: float):
-    if sentiment < float(os.environ["threshold_bad"]):
+    if sentiment < 0:
         return "red"
-    if sentiment > float(os.environ["threshold_good"]):
+    if sentiment > 0:
         return "green"
     return "yellow"
 
@@ -77,12 +77,12 @@ while True:
         if i < len(chats):
             msg_latest = chats[i][-1]
             mood_avg = ""
-            if msg_latest["average_sentiment"] > float(os.environ["threshold_good"]):
-                mood_avg = f"**:green[Good ({msg_latest['average_sentiment']:.2f})]**"
-            elif msg_latest["average_sentiment"] < float(os.environ["threshold_bad"]):
-                mood_avg = f"**:red[Bad ({msg_latest['average_sentiment']:.2f})]**"
+            if msg_latest["average_sentiment"] > 0:
+                mood_avg = "**:green[Good]**"
+            elif msg_latest["average_sentiment"] < 0:
+                mood_avg = "**:red[Bad]**"
             else:
-                mood_avg = f"**:orange[Neutral ({msg_latest['average_sentiment']:.2f})]**"
+                mood_avg = "**:orange[Neutral]**"
 
             with c[0].container():
                 st.subheader(f"Conversation #{i + 1}")

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -85,11 +85,11 @@ while True:
             msg_latest = chats[i][-1]
             mood_avg = ""
             if msg_latest["average_sentiment"] > 0:
-                mood_avg = f"**:green[Good]**"
+                mood_avg = "**:green[Good]**"
             elif msg_latest["average_sentiment"] < 0:
-                mood_avg = f"**:red[Bad]**"
+                mood_avg = "**:red[Bad]**"
             else:
-                mood_avg = f"**:orange[Neutral]**"
+                mood_avg = "**:orange[Neutral]**"
 
             with c[0].container():
                 st.subheader(f"Conversation #{i + 1}")

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -78,11 +78,11 @@ while True:
             msg_latest = chats[i][-1]
             mood_avg = ""
             if msg_latest["average_sentiment"] > 0:
-                mood_avg = "**:green[Good]**"
+                mood_avg = f"**:green[Good ({abs(msg_latest['average_sentiment']) * 100:.0f}%)]**"
             elif msg_latest["average_sentiment"] < 0:
-                mood_avg = "**:red[Bad]**"
+                mood_avg = f"**:red[Bad ({abs(msg_latest['average_sentiment']) * 100:.0f}%)]**"
             else:
-                mood_avg = "**:orange[Neutral]**"
+                mood_avg = f"**:orange[Neutral ({abs(msg_latest['average_sentiment']) * 100:.0f}%)]**"
 
             with c[0].container():
                 st.subheader(f"Conversation #{i + 1}")
@@ -93,8 +93,7 @@ while True:
             with c[1].container(border=True):
                 for msg in chats[i]:
                     with st.chat_message("human" if msg["role"] == "customer" else "assistant"):
-                        st.markdown(f"{msg['text']} <div style='text-align: right; color: {get_text_color(msg['sentiment'])}'>[{msg['sentiment']:.2f}]</div>", unsafe_allow_html=True)
-                        #st.markdown(f"{msg['text']} :{get_text_color(msg['sentiment'])}[[{msg['sentiment']:.2f}]]")
+                        st.markdown(f"{msg['text']} <div style='text-align: right; color: {get_text_color(msg['sentiment'])}'>[{abs(msg['sentiment']) * 100:.0f}%]</div>", unsafe_allow_html=True)
 
             chat_name = get_chat_name(i)
             for msg in chats[i]:

--- a/Streamlit Dashboard/main.py
+++ b/Streamlit Dashboard/main.py
@@ -45,12 +45,12 @@ alt_y = alt.Y("sentiment", axis=None)
 alt_legend = alt.Legend(title=None, orient="bottom", direction="vertical")
 alt_color = alt.Color("conversation", legend=alt_legend)
 
-def get_text_color(sentiment: float):
+def get_emoji(sentiment: float):
     if sentiment < 0:
-        return "red"
+        return "😀"
     if sentiment > 0:
-        return "green"
-    return "yellow"
+        return "😡"
+    return "😐"
 
 while True:
     count = 0
@@ -93,7 +93,7 @@ while True:
             with c[1].container(border=True):
                 for msg in chats[i]:
                     with st.chat_message("human" if msg["role"] == "customer" else "assistant"):
-                        st.markdown(f"{msg['text']} <div style='text-align: right; color: {get_text_color(msg['sentiment'])}'>[{abs(msg['sentiment']) * 100:.0f}%]</div>", unsafe_allow_html=True)
+                        st.markdown(f"{msg['text']} <div style='text-align: right'>{get_emoji(msg['sentiment'])}</div>", unsafe_allow_html=True)
 
             chat_name = get_chat_name(i)
             for msg in chats[i]:

--- a/quix.yaml
+++ b/quix.yaml
@@ -110,7 +110,7 @@ deployments:
   - name: Streamlit Dashboard
     application: Streamlit Dashboard
     deploymentType: Service
-    version: 0ba6b59351bc7daeec196c6f0eade9fbc60a971d
+    version: cbf485ae7288ceb82e6f1de5c27e58fe608ba764
     resources:
       cpu: 200
       memory: 500

--- a/quix.yaml
+++ b/quix.yaml
@@ -110,7 +110,7 @@ deployments:
   - name: Streamlit Dashboard
     application: Streamlit Dashboard
     deploymentType: Service
-    version: d98a43bca37bba87e8b097f8f7ee6e0c67e3372c
+    version: cdfb6460309d0cf59e2cfa6e3765afb2bdafeff3
     resources:
       cpu: 200
       memory: 500

--- a/quix.yaml
+++ b/quix.yaml
@@ -110,7 +110,7 @@ deployments:
   - name: Streamlit Dashboard
     application: Streamlit Dashboard
     deploymentType: Service
-    version: cdfb6460309d0cf59e2cfa6e3765afb2bdafeff3
+    version: 807b72b1c21a79c15fda4dc86881a3b9d90031f7
     resources:
       cpu: 200
       memory: 500

--- a/quix.yaml
+++ b/quix.yaml
@@ -110,7 +110,7 @@ deployments:
   - name: Streamlit Dashboard
     application: Streamlit Dashboard
     deploymentType: Service
-    version: 807b72b1c21a79c15fda4dc86881a3b9d90031f7
+    version: aee116d76f152f8d0836477742f809d7e95b095b
     resources:
       cpu: 200
       memory: 500

--- a/quix.yaml
+++ b/quix.yaml
@@ -110,7 +110,7 @@ deployments:
   - name: Streamlit Dashboard
     application: Streamlit Dashboard
     deploymentType: Service
-    version: cbf485ae7288ceb82e6f1de5c27e58fe608ba764
+    version: 5c512afd5e22571693068b81069a23db4dec76b9
     resources:
       cpu: 200
       memory: 500
@@ -145,6 +145,16 @@ deployments:
         description: Custom style sheet for Streamlit.
         required: false
         value: style.css
+      - name: threshold_good
+        inputType: FreeText
+        description: Sentiment values greater than this value are considered 'Good'.
+        required: true
+        value: 0.25
+      - name: threshold_bad
+        inputType: FreeText
+        description: Sentiment values below which are considered 'Bad'.
+        required: true
+        value: -0.25
 
 # This section describes the Topics of the data pipeline
 topics:

--- a/quix.yaml
+++ b/quix.yaml
@@ -40,7 +40,7 @@ deployments:
     state:
       enabled: true
       size: {{ ai_agent_state_size }}
-    desiredStatus: Running
+    desiredStatus: Stopped
     variables:
       - name: topic
         inputType: OutputTopic

--- a/quix.yaml
+++ b/quix.yaml
@@ -110,7 +110,7 @@ deployments:
   - name: Streamlit Dashboard
     application: Streamlit Dashboard
     deploymentType: Service
-    version: a53cb62d64df7506225353b5fc4ea0ba5856f315
+    version: d98a43bca37bba87e8b097f8f7ee6e0c67e3372c
     resources:
       cpu: 200
       memory: 500
@@ -145,16 +145,6 @@ deployments:
         description: Custom style sheet for Streamlit.
         required: false
         value: style.css
-      - name: threshold_good
-        inputType: FreeText
-        description: Sentiment values greater than this value are considered 'Good'.
-        required: true
-        value: 0.25
-      - name: threshold_bad
-        inputType: FreeText
-        description: Sentiment values below which are considered 'Bad'.
-        required: true
-        value: -0.25
 
 # This section describes the Topics of the data pipeline
 topics:

--- a/quix.yaml
+++ b/quix.yaml
@@ -40,7 +40,7 @@ deployments:
     state:
       enabled: true
       size: {{ ai_agent_state_size }}
-    desiredStatus: Stopped
+    desiredStatus: Running
     variables:
       - name: topic
         inputType: OutputTopic

--- a/quix.yaml
+++ b/quix.yaml
@@ -110,7 +110,7 @@ deployments:
   - name: Streamlit Dashboard
     application: Streamlit Dashboard
     deploymentType: Service
-    version: 5c512afd5e22571693068b81069a23db4dec76b9
+    version: a53cb62d64df7506225353b5fc4ea0ba5856f315
     resources:
       cpu: 200
       memory: 500


### PR DESCRIPTION
- Use env to set sentiment thresholds for classifying them as good, bad or neutral;
- Improve redis query by using key prefix to filter out chats from other workspaces;
- Display sentiment for individual text messages;
- General style improvements (font weight, color, etc.,);

Remarks: I wanted to fix the height of the containers showing the chats and make them scroll-able. Unfortunately this feature is not available until the [next Streamlit release - 1.30.0](https://github.com/streamlit/streamlit/issues/2169#issuecomment-1830296312).

Link to demo: https://dashboard-demo-llmcustomersupporttemplate-dashii.deployments.quix.io/?_ga=2.160253309.132085173.1702269010-1440560447.1688703233